### PR TITLE
V2

### DIFF
--- a/v2/go.mod
+++ b/v2/go.mod
@@ -1,0 +1,3 @@
+module github.com/cv-library/statsd/v2
+
+go 1.13

--- a/v2/statsd.go
+++ b/v2/statsd.go
@@ -73,7 +73,8 @@ func (t *timer) SendSampled(rate float64, names ...interface{}) (took time.Durat
 
 // Gauge sets arbitrary numeric value for a given metric.
 func Gauge(name string, value int64) {
-	return GaugeSampled(1.0, name, value)
+	GaugeSampled(1.0, name, value)
+	return
 }
 
 // GaugeSampled sets arbitrary numeric value for a given metric
@@ -100,7 +101,7 @@ func GaugeSampled(rate float64, name string, value int64) {
 
 // Inc increments a counter.
 func Inc(name string) {
-	return IncSampled(1.0, name)
+	IncSampled(1.0, name)
 }
 
 // IncSampled increments a counter with the given sample rate.
@@ -126,7 +127,7 @@ func IncSampled(rate float64, name string){
 
 // Time sends duration in ms for a given metric.
 func Time(name string, took time.Duration) {
-	return TimeSampled(1.0, name, took)
+	TimeSampled(1.0, name, took)
 }
 
 // TimeSampled sends duration in ms for a given metric

--- a/v2/statsd.go
+++ b/v2/statsd.go
@@ -1,0 +1,144 @@
+package statsd
+
+import (
+	"net"
+	"os"
+	"strconv"
+	"time"
+)
+
+// Address of the StatsD server.
+var Address = "localhost:8125"
+
+// AlsoAppendHost appends hostname along with any metric sent.
+var AlsoAppendHost = true
+
+// Cache the conn for perf.
+var conn net.Conn
+var host string
+
+func init() {
+	var err error
+
+	if host, err = os.Hostname(); err != nil {
+		panic(err)
+	}
+}
+
+func Timer() timer {
+	return timer{time.Now()}
+}
+
+// Timer
+type timer struct {
+	start time.Time
+}
+
+func (t *timer) Reset() {
+	t.start = time.Now()
+}
+
+func (t *timer) Send(names ...interface{}) (took time.Duration) {
+	took = time.Since(t.start)
+
+	if err := getConnection(); err != nil {
+		return
+	}
+
+	value := ":" + strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms"
+
+	for _, name := range names {
+		conn.Write([]byte(name.(string) + value))
+
+		// Send a host suffixed stat too.
+		if AlsoAppendHost {
+			conn.Write([]byte(name.(string) + "." + host + value))
+		}
+	}
+
+	return
+}
+
+// Gauge sets arbitrary numeric value for a given metric.
+func Gauge(name string, value int64) {
+	if err := getConnection(); err != nil {
+		return
+	}
+
+	suffix := ":" + strconv.FormatInt(value, 10) + "|g"
+
+	conn.Write([]byte(name + suffix))
+
+	// Send a host suffixed stat too.
+	if AlsoAppendHost {
+		conn.Write([]byte(name + "." + host + suffix))
+	}
+
+	return
+}
+
+// Inc is a simple counter adding one to a given metric.
+func Inc(name string) {
+	if err := getConnection(); err != nil {
+		return
+	}
+
+	conn.Write([]byte(name + ":1|c"))
+
+	// Send a host suffixed stat too.
+	if AlsoAppendHost {
+		conn.Write([]byte(name + "." + host + ":1|c"))
+	}
+
+	return
+}
+
+// IncSampled increments a counter with the given sample rate (between 0.0 - 1.0).
+// Example: Passing 0.1 tells statsd that this metric has been sample 1/10 times.
+// IE Reported metric will be 10x the number of times called.
+func IncSampled(name string, rate float64){
+	if err := getConnection(); err != nil {
+		return
+	}
+
+	rateString := "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+
+	conn.Write([]byte(name + ":1|c" + rateString))
+
+	// Send a host suffixed stat too.
+	if AlsoAppendHost {
+		conn.Write([]byte(name + "." + host + ":1|c" + rateString))
+	}
+
+	return
+}
+
+// Time sends duration in ms for a given metric.
+func Time(name string, took time.Duration) {
+	if err := getConnection(); err != nil {
+		return
+	}
+
+	value := ":" + strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms"
+
+	conn.Write([]byte(name + value))
+
+	// Send a host suffixed stat too.
+	if AlsoAppendHost {
+		conn.Write([]byte(name + "." + host + value))
+	}
+
+	return
+}
+
+func getConnection() (err error) {
+	// If we don't have a conn, make one.
+	if conn == nil {
+		if conn, err = net.Dial("udp", Address); err != nil {
+			conn = nil
+			return
+		}
+	}
+
+	return
+}

--- a/v2/statsd.go
+++ b/v2/statsd.go
@@ -38,7 +38,16 @@ func (t *timer) Reset() {
 	t.start = time.Now()
 }
 
+// Send takes a list of remote timer names, and submits the time that
+// has ellapsed since the creation of the timer to each in turn.
+// It returns a time.Duration representing the amount of time that was sent.
 func (t *timer) Send(names ...interface{}) (took time.Duration) {
+	return t.SendSampled(1.0, names...)
+}
+
+// SendSampled works like Send but sends the timing information
+// with the given sample rate.
+func (t *timer) SendSampled(rate float64, names ...interface{}) (took time.Duration) {
 	took = time.Since(t.start)
 
 	if err := getConnection(); err != nil {
@@ -46,6 +55,9 @@ func (t *timer) Send(names ...interface{}) (took time.Duration) {
 	}
 
 	value := ":" + strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms"
+	if rate < 1.0 {
+		value = value + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	}
 
 	for _, name := range names {
 		conn.Write([]byte(name.(string) + value))
@@ -61,11 +73,20 @@ func (t *timer) Send(names ...interface{}) (took time.Duration) {
 
 // Gauge sets arbitrary numeric value for a given metric.
 func Gauge(name string, value int64) {
+	return GaugeSampled(1.0, name, value)
+}
+
+// GaugeSampled sets arbitrary numeric value for a given metric
+// with the given sample rate.
+func GaugeSampled(rate float64, name string, value int64) {
 	if err := getConnection(); err != nil {
 		return
 	}
 
 	suffix := ":" + strconv.FormatInt(value, 10) + "|g"
+	if rate < 1.0 {
+		suffix = suffix + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	}
 
 	conn.Write([]byte(name + suffix))
 
@@ -77,14 +98,12 @@ func Gauge(name string, value int64) {
 	return
 }
 
-// Inc is a simple counter adding one to a given metric.
+// Inc increments a counter.
 func Inc(name string) {
 	return IncSampled(1.0, name)
 }
 
-// IncSampled increments a counter with the given sample rate (between 0.0 - 1.0).
-// Example: Passing 0.1 tells statsd that this metric has been sample 1/10 times.
-// IE Reported metric will be 10x the number of times called.
+// IncSampled increments a counter with the given sample rate.
 func IncSampled(rate float64, name string){
 	if err := getConnection(); err != nil {
 		return
@@ -107,11 +126,20 @@ func IncSampled(rate float64, name string){
 
 // Time sends duration in ms for a given metric.
 func Time(name string, took time.Duration) {
+	return TimeSampled(1.0, name, took)
+}
+
+// TimeSampled sends duration in ms for a given metric
+// with the given sample rate.
+func TimeSampled(rate float64, name string, took time.Duration) {
 	if err := getConnection(); err != nil {
 		return
 	}
 
 	value := ":" + strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms"
+	if rate < 1.0 {
+		value = value + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	}
 
 	conn.Write([]byte(name + value))
 

--- a/v2/statsd.go
+++ b/v2/statsd.go
@@ -79,18 +79,7 @@ func Gauge(name string, value int64) {
 
 // Inc is a simple counter adding one to a given metric.
 func Inc(name string) {
-	if err := getConnection(); err != nil {
-		return
-	}
-
-	conn.Write([]byte(name + ":1|c"))
-
-	// Send a host suffixed stat too.
-	if AlsoAppendHost {
-		conn.Write([]byte(name + "." + host + ":1|c"))
-	}
-
-	return
+	return IncSampled(name, 1.0)
 }
 
 // IncSampled increments a counter with the given sample rate (between 0.0 - 1.0).
@@ -101,13 +90,16 @@ func IncSampled(name string, rate float64){
 		return
 	}
 
-	rateString := "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	message := ":1|c";
+	if rate < 1.0 {
+		message = message + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	}
 
-	conn.Write([]byte(name + ":1|c" + rateString))
+	conn.Write([]byte(name + message))
 
 	// Send a host suffixed stat too.
 	if AlsoAppendHost {
-		conn.Write([]byte(name + "." + host + ":1|c" + rateString))
+		conn.Write([]byte(name + "." + host + message))
 	}
 
 	return

--- a/v2/statsd.go
+++ b/v2/statsd.go
@@ -79,13 +79,13 @@ func Gauge(name string, value int64) {
 
 // Inc is a simple counter adding one to a given metric.
 func Inc(name string) {
-	return IncSampled(name, 1.0)
+	return IncSampled(1.0, name)
 }
 
 // IncSampled increments a counter with the given sample rate (between 0.0 - 1.0).
 // Example: Passing 0.1 tells statsd that this metric has been sample 1/10 times.
 // IE Reported metric will be 10x the number of times called.
-func IncSampled(name string, rate float64){
+func IncSampled(rate float64, name string){
 	if err := getConnection(); err != nil {
 		return
 	}

--- a/v2/statsd_test.go
+++ b/v2/statsd_test.go
@@ -8,7 +8,177 @@ import (
 	"time"
 )
 
+func TestTime(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		dur, err := time.ParseDuration("1h30m45s")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		Time("foo", dur)
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(dur.Nanoseconds()/1e6), 10) + "|ms")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestTimeSampled(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		dur, err := time.ParseDuration("1h30m45s")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		TimeSampled(0.5, "foo", dur)
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(dur.Nanoseconds()/1e6), 10) + "|ms|@0.5")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestTimerReset(t *testing.T) {
+	timer := Timer()
+	time.Sleep(time.Millisecond)
+
+	then := timer.start
+	timer.Reset()
+
+	if then == timer.start {
+		t.Errorf("timer did not reset: was %s; is %s", then, timer.start)
+	}
+}
+
 func TestTimerSend(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		timer := Timer()
+		time.Sleep(time.Millisecond)
+
+		took := timer.Send("foo")
+		if took == 0 {
+			t.Error("Send() took no time")
+		}
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestTimerSendSampled(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		timer := Timer()
+		time.Sleep(time.Millisecond)
+
+		took := timer.SendSampled(0.5, "foo")
+		if took == 0 {
+			t.Error("Send() took no time")
+		}
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms|@0.5")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestInc(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		Inc("foo")
+
+		exp := []byte("foo:1|c")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestIncSampled(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		IncSampled(0.5, "foo")
+
+		exp := []byte("foo:1|c|@0.5")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestGauge(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		Gauge("foo", 42)
+
+		exp := []byte("foo:42|g")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestGaugeSampled(t *testing.T) {
+	test( t, func (conn *net.UDPConn) {
+		GaugeSampled(0.5, "foo", 42)
+
+		exp := []byte("foo:42|g|@0.5")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func test (t *testing.T, check func(*net.UDPConn) ) {
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 8125})
 	if err != nil {
 		t.Fatal(err)
@@ -17,25 +187,5 @@ func TestTimerSend(t *testing.T) {
 
 	conn.SetDeadline(time.Now().Add(time.Second))
 
-	timer := Timer()
-
-	time.Sleep(time.Millisecond)
-
-	took := timer.Send("foo")
-
-	if took == 0 {
-		t.Error("Send() took no time")
-	}
-
-	got := make([]byte, 8)
-	if _, _, err := conn.ReadFromUDP(got); err != nil {
-		t.Fatal(err)
-	}
-
-	exp := []byte("foo:" +
-		strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms")
-
-	if !bytes.Equal(got, exp) {
-		t.Errorf("got: %s; want: %s", got, exp)
-	}
+	check(conn)
 }

--- a/v2/statsd_test.go
+++ b/v2/statsd_test.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"testing"
 	"time"
+	"math/rand"
 )
 
 func TestTime(t *testing.T) {
@@ -187,5 +188,6 @@ func test (t *testing.T, check func(*net.UDPConn) ) {
 
 	conn.SetDeadline(time.Now().Add(time.Second))
 
+	rand.Seed(1)
 	check(conn)
 }

--- a/v2/statsd_test.go
+++ b/v2/statsd_test.go
@@ -1,0 +1,41 @@
+package statsd
+
+import (
+	"bytes"
+	"net"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestTimerSend(t *testing.T) {
+	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 8125})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Close()
+
+	conn.SetDeadline(time.Now().Add(time.Second))
+
+	timer := Timer()
+
+	time.Sleep(time.Millisecond)
+
+	took := timer.Send("foo")
+
+	if took == 0 {
+		t.Error("Send() took no time")
+	}
+
+	got := make([]byte, 8)
+	if _, _, err := conn.ReadFromUDP(got); err != nil {
+		t.Fatal(err)
+	}
+
+	exp := []byte("foo:" +
+		strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms")
+
+	if !bytes.Equal(got, exp) {
+		t.Errorf("got: %s; want: %s", got, exp)
+	}
+}


### PR DESCRIPTION
The main point of this bump is to add support for using a sampling rate with the current functions. An `IncSampled` was added in 98dec1329365a4c but no equivalent functions for `timer.Send`, `Time`, or `Gauge` were added.

A problem with adding these as new functions is that `IncSampled` placed the sampling rate argument at the end of the signature, but some of our existing functions (eg. `timer.Send`) take a variadic list of timer names, so that would not work.

This PR solves this by moving the sampling rate to the start of the signature and provigind `*Sampled` variants of all existing functions that take an additional sampling rate `float64` _as the first argument_.

This also includes an expanded test suite, done in the least efficient way possible for now. This is ripe for later improvements. 