### PR TITLE
Add sampling support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,8 +16,13 @@ func main() {
 
     // Do stuff
 
-    // Note: Lack of support for sampling yet.
-    timer.send("metric.name", "metric.name2")
+    timer.Send("metric.name", "metric.name2")
+
+    // Or using a sampling rate
+    timer.SendWithOptions(
+        &statsd.Options{ Rate: 0.5 },
+        "sampled.metric",
+    )
 }
 ```
 

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,99 @@
+package statsd_test
+
+import (
+	"fmt"
+	"time"
+	"github.com/cv-library/statsd"
+)
+
+func ExampleTiming() {
+	for i:=0; i<10; i++ {
+		timer := statsd.Timer()
+
+		// Do work
+
+		took := timer.Send("work.duration")
+		timer.SendWithOptions(
+			&statsd.Options{ Rate: 0.25 },
+			"work.duration.sampled",
+		)
+
+		fmt.Printf("Took %f seconds\n", took.Seconds())
+	}
+}
+
+func ExampleTimer() {
+	// This is slightly more efficient than the Timing example
+	// since we avoid creating a new Timing every time
+	timer := statsd.Timer()
+	for i:=0; i<10; i++ {
+		timer.Reset()
+
+		// Do work
+
+		took := timer.Send("work.duration")
+		timer.SendWithOptions(
+			&statsd.Options{ Rate: 0.25 },
+			"work.duration.sampled",
+		)
+
+		fmt.Printf("Took %f seconds\n", took.Seconds())
+	}
+}
+
+func ExampleTime() {
+	for i:=0; i<10; i++ {
+		start := time.Now()
+
+		// Do work
+
+		statsd.Time("work.duration", time.Since(start))
+	}
+}
+
+func ExampleTimeWithOptions() {
+	for i:=0; i<10; i++ {
+		start := time.Now()
+
+		// Do work
+
+		if i % 2 == 0 {
+			continue
+		}
+
+		// We use AlwaysSend: true here because we're doing the sampling
+		// ourselves; we want every packet to reach the server
+		statsd.TimeWithOptions(
+			&statsd.Options{ Rate: 0.5, AlwaysSend: true },
+			"work.duration.sampled",
+			time.Since(start),
+		)
+	}
+}
+
+func ExampleInc() {
+	// Increment a counter
+	statsd.Inc("stats.success")
+}
+
+func ExampleIncWithOptions() {
+	// Increment a counter every other time
+	statsd.IncWithOptions(
+		&statsd.Options{ Rate: 0.5 },
+		"stats.success",
+	)
+}
+
+func ExampleGauge() {
+	// Set page size to 10
+	statsd.Gauge("page.size", 10)
+}
+
+func ExampleGaugeWithOptions() {
+	// Set page size to 10 every other time
+	statsd.GaugeWithOptions(
+		&statsd.Options{ Rate: 0.5 },
+		"page.size",
+		10,
+	)
+}

--- a/statsd.go
+++ b/statsd.go
@@ -21,7 +21,7 @@ var DefaultOptions = &Options{
 	AlwaysSend: false,
 }
 
-// Cache the conn for perf.
+// Cache the connection for performance
 var conn net.Conn
 var host string
 
@@ -70,7 +70,7 @@ func (t *timer) Reset() {
 }
 
 // Send takes a list of remote timer names, and submits the time that
-// has ellapsed since the creation of the timer to each in turn.
+// has elapsed since the creation of the timer to each in turn.
 // It returns a time.Duration representing the amount of time that was sent.
 func (t *timer) Send(names ...interface{}) (took time.Duration) {
 	return t.SendWithOptions(nil, names...)

--- a/statsd.go
+++ b/statsd.go
@@ -35,10 +35,6 @@ func init() {
 	}
 }
 
-func Timer() timer {
-	return timer{time.Now()}
-}
-
 // Options holds key/value pairs to be used when calling the functions
 // with the "...WithOptions" suffix.
 type Options struct {
@@ -63,6 +59,12 @@ type timer struct {
 	start time.Time
 }
 
+// Timer returns a new timer set to `time.Now()`
+func Timer() timer {
+	return timer{time.Now()}
+}
+
+// Reset sets the start time for the timer to `time.Now()`
 func (t *timer) Reset() {
 	t.start = time.Now()
 }

--- a/statsd.go
+++ b/statsd.go
@@ -122,6 +122,17 @@ func Inc(name string) {
 	IncWithOptions(nil, name)
 }
 
+// IncSampled increments a counter with the given sample rate.
+// Note that this function will send the data to the server every time
+// it is called. It is the caller's responsibility to implement the
+// sampling.
+//
+// Deprecated: Use IncWithOptions and pass the sampling rate
+// using the Options struct.
+func IncSampled(name string, rate float64) {
+	IncWithOptions(&Options{Rate: rate, AlwaysSend: true}, name)
+}
+
 // IncWithOptions increments a counter using the provided options.
 func IncWithOptions(options *Options, name string) {
 	var message string

--- a/statsd.go
+++ b/statsd.go
@@ -1,6 +1,7 @@
 package statsd
 
 import (
+	"math/rand"
 	"net"
 	"os"
 	"strconv"
@@ -19,6 +20,8 @@ var host string
 
 func init() {
 	var err error
+
+	rand.Seed(time.Now().UTC().UnixNano())
 
 	if host, err = os.Hostname(); err != nil {
 		panic(err)
@@ -50,22 +53,17 @@ func (t *timer) Send(names ...interface{}) (took time.Duration) {
 func (t *timer) SendSampled(rate float64, names ...interface{}) (took time.Duration) {
 	took = time.Since(t.start)
 
-	if err := getConnection(); err != nil {
+	var message string
+	if sampled, suffix := sampleData(rate); sampled {
+		message = ":" +
+			strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) +
+			"|ms" + suffix
+	} else {
 		return
 	}
 
-	value := ":" + strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms"
-	if rate < 1.0 {
-		value = value + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
-	}
-
 	for _, name := range names {
-		conn.Write([]byte(name.(string) + value))
-
-		// Send a host suffixed stat too.
-		if AlsoAppendHost {
-			conn.Write([]byte(name.(string) + "." + host + value))
-		}
+		send(name.(string), message)
 	}
 
 	return
@@ -80,23 +78,14 @@ func Gauge(name string, value int64) {
 // GaugeSampled sets arbitrary numeric value for a given metric
 // with the given sample rate.
 func GaugeSampled(rate float64, name string, value int64) {
-	if err := getConnection(); err != nil {
+	var message string
+	if sampled, suffix := sampleData(rate); sampled {
+		message = ":" + strconv.FormatInt(value, 10) + "|g" + suffix
+	} else {
 		return
 	}
 
-	suffix := ":" + strconv.FormatInt(value, 10) + "|g"
-	if rate < 1.0 {
-		suffix = suffix + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
-	}
-
-	conn.Write([]byte(name + suffix))
-
-	// Send a host suffixed stat too.
-	if AlsoAppendHost {
-		conn.Write([]byte(name + "." + host + suffix))
-	}
-
-	return
+	send(name, message)
 }
 
 // Inc increments a counter.
@@ -106,13 +95,39 @@ func Inc(name string) {
 
 // IncSampled increments a counter with the given sample rate.
 func IncSampled(rate float64, name string) {
-	if err := getConnection(); err != nil {
+	var message string
+	if sampled, suffix := sampleData(rate); sampled {
+		message = ":1|c" + suffix
+	} else {
 		return
 	}
 
-	message := ":1|c"
-	if rate < 1.0 {
-		message = message + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	send(name, message)
+}
+
+// Time sends duration in ms for a given metric.
+func Time(name string, took time.Duration) {
+	TimeSampled(1.0, name, took)
+}
+
+// TimeSampled sends duration in ms for a given metric
+// with the given sample rate.
+func TimeSampled(rate float64, name string, took time.Duration) {
+	var message string
+	if sampled, suffix := sampleData(rate); sampled {
+		message = ":" +
+			strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) +
+			"|ms" + suffix
+	} else {
+		return
+	}
+
+	send(name, message)
+}
+
+func send(name string, message string) {
+	if err := getConnection(); err != nil {
+		return
 	}
 
 	conn.Write([]byte(name + message))
@@ -125,31 +140,16 @@ func IncSampled(rate float64, name string) {
 	return
 }
 
-// Time sends duration in ms for a given metric.
-func Time(name string, took time.Duration) {
-	TimeSampled(1.0, name, took)
-}
-
-// TimeSampled sends duration in ms for a given metric
-// with the given sample rate.
-func TimeSampled(rate float64, name string, took time.Duration) {
-	if err := getConnection(); err != nil {
-		return
+func sampleData(rate float64) (bool, string) {
+	if rate == 1.0 {
+		return true, ""
 	}
 
-	value := ":" + strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms"
-	if rate < 1.0 {
-		value = value + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	if rand.Float64() >= rate {
+		return false, ""
 	}
 
-	conn.Write([]byte(name + value))
-
-	// Send a host suffixed stat too.
-	if AlsoAppendHost {
-		conn.Write([]byte(name + "." + host + value))
-	}
-
-	return
+	return true, "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
 }
 
 func getConnection() (err error) {

--- a/statsd.go
+++ b/statsd.go
@@ -54,31 +54,32 @@ type Options struct {
 	AlwaysSend bool
 }
 
-// Timer
-type timer struct {
+// Timing keeps track of a point in time, and makes it simpler to send
+// timing stats to the server based on that starting point.
+type Timing struct {
 	start time.Time
 }
 
-// Timer returns a new timer set to `time.Now()`
-func Timer() timer {
-	return timer{time.Now()}
+// Timer returns a new Timing set to `time.Now()`
+func Timer() Timing {
+	return Timing{time.Now()}
 }
 
 // Reset sets the start time for the timer to `time.Now()`
-func (t *timer) Reset() {
+func (t *Timing) Reset() {
 	t.start = time.Now()
 }
 
 // Send takes a list of remote timer names, and submits the time that
 // has elapsed since the creation of the timer to each in turn.
 // It returns a time.Duration representing the amount of time that was sent.
-func (t *timer) Send(names ...interface{}) (took time.Duration) {
+func (t *Timing) Send(names ...interface{}) (took time.Duration) {
 	return t.SendWithOptions(nil, names...)
 }
 
 // SendWithOptions works like Send but sends the timing information
 // using the provided options.
-func (t *timer) SendWithOptions(
+func (t *Timing) SendWithOptions(
 	options *Options,
 	names ...interface{},
 ) (took time.Duration) {

--- a/statsd.go
+++ b/statsd.go
@@ -79,13 +79,13 @@ func Gauge(name string, value int64) {
 
 // Inc is a simple counter adding one to a given metric.
 func Inc(name string) {
-	return IncSampled(name, 1.0)
+	return IncSampled(1.0, name)
 }
 
 // IncSampled increments a counter with the given sample rate (between 0.0 - 1.0).
 // Example: Passing 0.1 tells statsd that this metric has been sample 1/10 times.
 // IE Reported metric will be 10x the number of times called.
-func IncSampled(name string, rate float64) {
+func IncSampled(rate float64, name string) {
 	if err := getConnection(); err != nil {
 		return
 	}

--- a/statsd.go
+++ b/statsd.go
@@ -79,35 +79,27 @@ func Gauge(name string, value int64) {
 
 // Inc is a simple counter adding one to a given metric.
 func Inc(name string) {
-	if err := getConnection(); err != nil {
-		return
-	}
-
-	conn.Write([]byte(name + ":1|c"))
-
-	// Send a host suffixed stat too.
-	if AlsoAppendHost {
-		conn.Write([]byte(name + "." + host + ":1|c"))
-	}
-
-	return
+	return IncSampled(name, 1.0)
 }
 
 // IncSampled increments a counter with the given sample rate (between 0.0 - 1.0).
 // Example: Passing 0.1 tells statsd that this metric has been sample 1/10 times.
 // IE Reported metric will be 10x the number of times called.
-func IncSampled(name string, rate float64){
+func IncSampled(name string, rate float64) {
 	if err := getConnection(); err != nil {
 		return
 	}
 
-	rateString := "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	message := ":1|c"
+	if rate < 1.0 {
+		message = message + "|@" + strconv.FormatFloat(rate, 'f', -1, 64)
+	}
 
-	conn.Write([]byte(name + ":1|c" + rateString))
+	conn.Write([]byte(name + message))
 
 	// Send a host suffixed stat too.
 	if AlsoAppendHost {
-		conn.Write([]byte(name + "." + host + ":1|c" + rateString))
+		conn.Write([]byte(name + "." + host + message))
 	}
 
 	return

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -2,6 +2,7 @@ package statsd
 
 import (
 	"bytes"
+	"math/rand"
 	"net"
 	"strconv"
 	"testing"
@@ -187,5 +188,6 @@ func test(t *testing.T, check func(*net.UDPConn)) {
 
 	conn.SetDeadline(time.Now().Add(time.Second))
 
+	rand.Seed(2) // First call to rand.Float64() == 0.167297
 	check(conn)
 }

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -32,14 +32,14 @@ func TestTime(t *testing.T) {
 	})
 }
 
-func TestTimeSampled(t *testing.T) {
+func TestTimeWithOptions(t *testing.T) {
 	test(t, func(conn *net.UDPConn) {
 		dur, err := time.ParseDuration("1h30m45s")
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		TimeSampled(0.5, "foo", dur)
+		TimeWithOptions(&Options{Rate: 0.5}, "foo", dur)
 
 		exp := []byte("foo:" +
 			strconv.FormatUint(uint64(dur.Nanoseconds()/1e6), 10) + "|ms|@0.5")
@@ -91,12 +91,12 @@ func TestTimerSend(t *testing.T) {
 	})
 }
 
-func TestTimerSendSampled(t *testing.T) {
+func TestTimerSendWithOptions(t *testing.T) {
 	test(t, func(conn *net.UDPConn) {
 		timer := Timer()
 		time.Sleep(time.Millisecond)
 
-		took := timer.SendSampled(0.5, "foo")
+		took := timer.SendWithOptions(&Options{Rate: 0.5}, "foo")
 		if took == 0 {
 			t.Error("Send() took no time")
 		}
@@ -131,11 +131,11 @@ func TestInc(t *testing.T) {
 	})
 }
 
-func TestIncSampled(t *testing.T) {
+func TestIncWithOptions(t *testing.T) {
 	test(t, func(conn *net.UDPConn) {
-		IncSampled(0.5, "foo")
+		IncWithOptions(&Options{Rate: 0.1, AlwaysSend: true}, "foo")
 
-		exp := []byte("foo:1|c|@0.5")
+		exp := []byte("foo:1|c|@0.1")
 		got := make([]byte, len(exp))
 		if _, _, err := conn.ReadFromUDP(got); err != nil {
 			t.Fatal(err)
@@ -163,9 +163,9 @@ func TestGauge(t *testing.T) {
 	})
 }
 
-func TestGaugeSampled(t *testing.T) {
+func TestGaugeWithOptions(t *testing.T) {
 	test(t, func(conn *net.UDPConn) {
-		GaugeSampled(0.5, "foo", 42)
+		GaugeWithOptions(&Options{Rate: 0.5}, "foo", 42)
 
 		exp := []byte("foo:42|g|@0.5")
 		got := make([]byte, len(exp))

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -8,7 +8,177 @@ import (
 	"time"
 )
 
+func TestTime(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		dur, err := time.ParseDuration("1h30m45s")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		Time("foo", dur)
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(dur.Nanoseconds()/1e6), 10) + "|ms")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestTimeSampled(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		dur, err := time.ParseDuration("1h30m45s")
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		TimeSampled(0.5, "foo", dur)
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(dur.Nanoseconds()/1e6), 10) + "|ms|@0.5")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestTimerReset(t *testing.T) {
+	timer := Timer()
+	time.Sleep(time.Millisecond)
+
+	then := timer.start
+	timer.Reset()
+
+	if then == timer.start {
+		t.Errorf("timer did not reset: was %s; is %s", then, timer.start)
+	}
+}
+
 func TestTimerSend(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		timer := Timer()
+		time.Sleep(time.Millisecond)
+
+		took := timer.Send("foo")
+		if took == 0 {
+			t.Error("Send() took no time")
+		}
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestTimerSendSampled(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		timer := Timer()
+		time.Sleep(time.Millisecond)
+
+		took := timer.SendSampled(0.5, "foo")
+		if took == 0 {
+			t.Error("Send() took no time")
+		}
+
+		exp := []byte("foo:" +
+			strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms|@0.5")
+
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestInc(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		Inc("foo")
+
+		exp := []byte("foo:1|c")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestIncSampled(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		IncSampled(0.5, "foo")
+
+		exp := []byte("foo:1|c|@0.5")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestGauge(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		Gauge("foo", 42)
+
+		exp := []byte("foo:42|g")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func TestGaugeSampled(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		GaugeSampled(0.5, "foo", 42)
+
+		exp := []byte("foo:42|g|@0.5")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
+func test(t *testing.T, check func(*net.UDPConn)) {
 	conn, err := net.ListenUDP("udp", &net.UDPAddr{Port: 8125})
 	if err != nil {
 		t.Fatal(err)
@@ -17,25 +187,5 @@ func TestTimerSend(t *testing.T) {
 
 	conn.SetDeadline(time.Now().Add(time.Second))
 
-	timer := Timer()
-
-	time.Sleep(time.Millisecond)
-
-	took := timer.Send("foo")
-
-	if took == 0 {
-		t.Error("Send() took no time")
-	}
-
-	got := make([]byte, 8)
-	if _, _, err := conn.ReadFromUDP(got); err != nil {
-		t.Fatal(err)
-	}
-
-	exp := []byte("foo:" +
-		strconv.FormatUint(uint64(took.Nanoseconds()/1e6), 10) + "|ms")
-
-	if !bytes.Equal(got, exp) {
-		t.Errorf("got: %s; want: %s", got, exp)
-	}
+	check(conn)
 }

--- a/statsd_test.go
+++ b/statsd_test.go
@@ -131,6 +131,23 @@ func TestInc(t *testing.T) {
 	})
 }
 
+// This function is deprecated, but we test it while we have it
+func TestIncSampled(t *testing.T) {
+	test(t, func(conn *net.UDPConn) {
+		IncSampled("foo", 0.5)
+
+		exp := []byte("foo:1|c|@0.5")
+		got := make([]byte, len(exp))
+		if _, _, err := conn.ReadFromUDP(got); err != nil {
+			t.Fatal(err)
+		}
+
+		if !bytes.Equal(got, exp) {
+			t.Errorf("got: %s; want: %s", got, exp)
+		}
+	})
+}
+
 func TestIncWithOptions(t *testing.T) {
 	test(t, func(conn *net.UDPConn) {
 		IncWithOptions(&Options{Rate: 0.1, AlwaysSend: true}, "foo")


### PR DESCRIPTION
The main point of this change is to add support for using a sampling rate with the current functions. An `IncSampled` was added in 98dec13 but no equivalent functions for `timer.Send`, `Time`, or `Gauge` were added.

A problem with adding these as new functions is that `IncSampled` placed the sampling rate argument at the end of the signature, but some of our existing functions (eg. `timer.Send`) take a variadic list of timer names, so that would not work.

This PR solves this by adding a `statsd.Options` struct to hold options such as the desired sample rate, and a new set of `*WithOptions` functions to go with it that take a `*statsd.Options` as their first argument (which means that they should be callable with our defaults by passing `nil`). A `statsd.DefaultOptions()` function is also exported, to provide a copy of those defaults.

This also includes an expanded test suite, done in the least efficient way possible for now. This is ripe for later improvements.

The changes in this PR should be backwards compatible, and the `IncSampled` function remains unchanged, but with a deprecation notice.